### PR TITLE
Reimplemented Icon Support.

### DIFF
--- a/Fabric/src/main/java/chylex/customwindowtitle/fabric/CustomWindowTitle.java
+++ b/Fabric/src/main/java/chylex/customwindowtitle/fabric/CustomWindowTitle.java
@@ -11,7 +11,7 @@ public class CustomWindowTitle implements ClientModInitializer {
 	private final TitleConfig config;
 	
 	public CustomWindowTitle() {
-		config = TitleConfig.read(FabricLoader.getInstance().getConfigDir().toAbsolutePath().toString());
+		config = TitleConfig.load(FabricLoader.getInstance().getConfigDir().toAbsolutePath().toString());
 	}
 	
 	@Override

--- a/NeoForge/src/main/java/chylex/customwindowtitle/neoforge/CustomWindowTitle.java
+++ b/NeoForge/src/main/java/chylex/customwindowtitle/neoforge/CustomWindowTitle.java
@@ -16,7 +16,7 @@ public class CustomWindowTitle {
 	private final TitleConfig config;
 	
 	public CustomWindowTitle(IEventBus eventBus) {
-		config = TitleConfig.read(FMLPaths.CONFIGDIR.get().toString());
+		config = TitleConfig.load(FMLPaths.CONFIGDIR.get().toString());
 		eventBus.addListener(this::onClientSetup);
 		CommonTokenData.register(new TokenProvider());
 	}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ To change the title or icon, navigate to the `.minecraft/config` folder, and ope
 
 ```toml
 title = 'Minecraft {mcversion}'  
-icon16 = ''  
-icon32 = ''
+icon = ''  
 ```
 
 Only edit text inside quotes or apostrophes.
@@ -32,22 +31,29 @@ If any of the tokens aren't working, search the game log for **CustomWindowTitle
 
 ### Changing the Icon
 
-**This feature is currently not supported in Minecraft 1.20+.**
+#### Minecraft 1.21+
 
-You must create two PNG images with sizes 16x16 and 32x32 pixels. The images **must be saved with transparency** even if they don't use it, **otherwise the icons will appear corrupted**. In Krita for example, you must check _Store alpha channel (transparency)_ when saving the image.
+**This feature is only available in Custom Window Title 1.4.0 and newer.**
 
-The _icon16_ and _icon32_ configuration entries point to the PNG files relative to the `.minecraft/config` folder. For example, if you place the two icons in a folder named _customwindowtitle_ as follows:
+Create a square PNG image whose dimensions are a power of two, such as 32x32 or 48x48. Put the PNG file into the `.minecraft/config` folder, either directly or into a subfolder.
 
-* `.minecraft/config/customwindowtitle-client.toml`
-* `.minecraft/config/customwindowtitle/icon16.png`
-* `.minecraft/config/customwindowtitle/icon32.png`
+The icon **must be saved with transparency** even if it don't use it, otherwise the icon may be corrupted or not appear at all. In Krita for example, you must check _Store alpha channel (transparency)_ when saving.
 
-Then, the two icon entries should look like this:
+The _icon_ configuration entry points to the PNG file relative to `.minecraft/config`.
+
+For example, if you placed the icon into `.minecraft/config/customwindowtitle/icon.png`, then the configuration entry should look like this:
 
 ```toml
-icon16 = 'customwindowtitle/icon16.png'  
-icon32 = 'customwindowtitle/icon32.png'
+icon = 'customwindowtitle/icon.png'
 ```
+
+#### Minecraft 1.20
+
+This feature is not available in Minecraft 1.20.
+
+#### Minecraft 1.19 and older
+
+Instead of one `icon` configuration entry, there are two configuration entries `icon16` and `icon32` for icons with dimensions 16x16 and 32x32.
 
 ## Screenshots
 

--- a/src/main/java/chylex/customwindowtitle/IconChanger.java
+++ b/src/main/java/chylex/customwindowtitle/IconChanger.java
@@ -1,0 +1,60 @@
+package chylex.customwindowtitle;
+
+import net.minecraft.client.Minecraft;
+import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWImage;
+import org.lwjgl.stb.STBImage;
+import org.lwjgl.system.MemoryStack;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class IconChanger {
+	private IconChanger() {}
+	
+	public static void setIcon(Path iconPath) {
+		long windowHandle = Minecraft.getInstance().getWindow().getWindow();
+		setWindowIcon(windowHandle, iconPath);
+	}
+	
+	private static void setWindowIcon(long windowHandle, Path iconPath) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			IntBuffer w = stack.mallocInt(1);
+			IntBuffer h = stack.mallocInt(1);
+			IntBuffer channels = stack.mallocInt(1);
+			
+			ByteBuffer icon = loadIcon(iconPath, w, h, channels);
+			if (icon == null) {
+				return;
+			}
+			
+			try (GLFWImage glfwImage1 = GLFWImage.malloc(); GLFWImage glfwImage2 = GLFWImage.malloc(); GLFWImage.Buffer icons = GLFWImage.malloc(2)) {
+				glfwImage1.set(w.get(0), h.get(0), icon);
+				glfwImage2.set(w.get(0), h.get(0), icon);
+				
+				icons.put(0, glfwImage1);
+				icons.put(1, glfwImage2);
+				
+				GLFW.glfwSetWindowIcon(windowHandle, icons);
+			}
+		} catch (Exception e) {
+			System.err.println("Failed to set window icon: " + iconPath);
+			e.printStackTrace();
+		}
+	}
+	
+	private static ByteBuffer loadIcon(Path path, IntBuffer w, IntBuffer h, IntBuffer channels) throws IOException {
+		byte[] iconBytes = Files.readAllBytes(path);
+		
+		ByteBuffer buffer = ByteBuffer.allocateDirect(iconBytes.length).put(iconBytes).flip();
+		ByteBuffer icon = STBImage.stbi_load_from_memory(buffer, w, h, channels, 4);
+		
+		if (icon == null) {
+			System.err.println("Failed to load image from memory for: " + path + " - " + STBImage.stbi_failure_reason());
+		}
+		
+		return icon;
+	}
+}

--- a/src/main/java/chylex/customwindowtitle/TitleConfig.java
+++ b/src/main/java/chylex/customwindowtitle/TitleConfig.java
@@ -1,7 +1,6 @@
 package chylex.customwindowtitle;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -12,47 +11,79 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class TitleConfig {
+	private static final String KEY_TITLE = "title";
+	private static final String KEY_ICON = "icon";
+	
 	private static final ImmutableMap<String, String> DEFAULTS = ImmutableMap.<String, String>builder()
-		.put("title", "Minecraft {mcversion}")
-		.build();
+		.put(KEY_TITLE, "Minecraft {mcversion}")
+		.put(KEY_ICON, "")
+		.buildOrThrow();
 	
-	private static final ImmutableSet<String> IGNORED_KEYS = ImmutableSet.of(
-		"icon16",
-		"icon32"
-	);
+	private static volatile TitleConfig instance;
 	
-	public static TitleConfig read(final String folder) {
-		final Path configFile = Paths.get(folder, "customwindowtitle-client.toml");
-		final Map<String, String> config = new LinkedHashMap<>(DEFAULTS);
+	public static TitleConfig getInstance() {
+		return instance;
+	}
+	
+	public static TitleConfig load(String folder) {
+		if (instance != null) {
+			throw new IllegalStateException("TitleConfig has already been loaded and cannot be loaded again.");
+		}
+		
+		if (instance == null) {
+			synchronized(TitleConfig.class) {
+				if (instance == null) {
+					instance = loadImpl(folder);
+				}
+			}
+		}
+		
+		return instance;
+	}
+	
+	private static TitleConfig loadImpl(String folder) {
+		Path configFile = Paths.get(folder, "customwindowtitle-client.toml");
+		Map<String, String> config = new LinkedHashMap<>(DEFAULTS);
 		
 		try {
 			if (!Files.exists(configFile)) {
-				Files.write(configFile, config.entrySet().stream().map(entry -> String.format("%s = '%s'", entry.getKey(), entry.getValue())).collect(Collectors.toList()), StandardCharsets.UTF_8);
+				Files.write(configFile, config.entrySet().stream()
+					.map(entry -> String.format("%s = '%s'", entry.getKey(), entry.getValue()))
+					.collect(Collectors.toList()), StandardCharsets.UTF_8);
 			}
 			else {
-				Files.readAllLines(configFile, StandardCharsets.UTF_8).stream().map(String::trim).filter(line -> !line.isEmpty()).forEach(line -> {
-					final String[] split = line.split("=", 2);
-					
-					if (split.length != 2) {
-						throw new RuntimeException("CustomWindowTitle configuration has an invalid line: " + line);
-					}
-					
-					final String key = split[0].trim();
-					final String value = parseTrimmedValue(split[1].trim());
-					
-					if (config.containsKey(key)) {
-						config.put(key, value);
-					}
-					else if (!IGNORED_KEYS.contains(key)) {
-						throw new RuntimeException("CustomWindowTitle configuration has an invalid key: " + key);
-					}
-				});
+				Files.readAllLines(configFile, StandardCharsets.UTF_8).stream()
+					.map(String::trim)
+					.filter(line -> !line.isEmpty())
+					.forEach(line -> {
+						String[] split = line.split("=", 2);
+						
+						if (split.length != 2) {
+							throw new RuntimeException("CustomWindowTitle configuration has an invalid line: " + line);
+						}
+						
+						String key = split[0].trim();
+						String value = parseTrimmedValue(split[1].trim());
+						
+						if (config.containsKey(key)) {
+							config.put(key, value);
+						}
+						else {
+							throw new RuntimeException("CustomWindowTitle configuration has an invalid key: " + key);
+						}
+					});
 			}
-		} catch (final IOException e) {
+		} catch (IOException e) {
 			throw new RuntimeException("CustomWindowTitle configuration error", e);
 		}
 		
-		return new TitleConfig(config.get("title"));
+		String iconPathStr = config.get(KEY_ICON);
+		Path iconPath = iconPathStr.isEmpty() ? null : Paths.get(folder, iconPathStr);
+		if (iconPath != null && Files.notExists(iconPath)) {
+			throw new RuntimeException("CustomWindowTitle configuration points to a missing icon: " + iconPath);
+		}
+		
+		return new TitleConfig(config.get(KEY_TITLE), iconPath);
 	}
 	
 	private static String parseTrimmedValue(String value) {
@@ -75,12 +106,22 @@ public final class TitleConfig {
 	}
 	
 	private final String title;
+	private final Path icon;
 	
-	private TitleConfig(final String title) {
+	private TitleConfig(final String title, final Path icon) {
 		this.title = title;
+		this.icon = icon;
 	}
 	
 	public String getTitle() {
 		return title;
+	}
+	
+	public boolean hasIcon() {
+		return icon != null;
+	}
+	
+	public Path getIconPath() {
+		return icon;
 	}
 }

--- a/src/main/java/chylex/customwindowtitle/mixin/InitializeCustomIcon.java
+++ b/src/main/java/chylex/customwindowtitle/mixin/InitializeCustomIcon.java
@@ -1,0 +1,20 @@
+package chylex.customwindowtitle.mixin;
+
+import chylex.customwindowtitle.IconChanger;
+import chylex.customwindowtitle.TitleConfig;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Minecraft.class)
+public final class InitializeCustomIcon {
+	@Inject(method = "onResourceLoadFinished", at = @At("HEAD"))
+	private void onFinishedLoading(CallbackInfo callbackInfo) {
+		TitleConfig config = TitleConfig.getInstance();
+		if (config != null && config.hasIcon()) {
+			IconChanger.setIcon(config.getIconPath());
+		}
+	}
+}

--- a/src/main/resources/customwindowtitle.mixins.json
+++ b/src/main/resources/customwindowtitle.mixins.json
@@ -5,7 +5,8 @@
   "refmap": "customwindowtitle.refmap.json",
   "compatibilityLevel": "JAVA_17",
   "client": [
-    "DisableVanillaTitle"
+    "DisableVanillaTitle",
+    "InitializeCustomIcon"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Reimplemented Icon Support.

Used Lambda functions for config reading.

You now only need to provide one Icon and the Pixel Width and Height no longer matters, for a clean look I suggest using a square icon.
